### PR TITLE
README: fix logo for dark mode, rename references to flow/agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Flow Modules
+# Alloy Modules
 
 <!-- markdownlint-disable MD033 -->
 <a href="https://grafana.com">
@@ -6,10 +6,9 @@
 </a>
 
 <p align="center">
-    <img src="assets/logo_alloy_dark.svg" alt="Grafana Alloy logo" height="100px">
+    <img src="assets/logo_alloy_light.svg#gh-dark-mode-only" alt="Grafana Alloy logo" height="100px">
+    <img src="assets/logo_alloy_dark.svg#gh-light-mode-only" alt="Grafana Alloy logo" height="100px">
 </p>
-
-**NOTE: This is only to be used for Modules not Modules Classic.**
 
 [Modules](https://grafana.com/docs/alloy/latest/concepts/modules/) are a way to create Grafana [Alloy](https://grafana.com/docs/alloy/latest/) configurations which can be loaded as a component. Modules are a great way to parameterize a configuration to create reusable pipelines.
 
@@ -19,7 +18,7 @@ Create a folder for the module under the `./modules` directory in the appropriat
 
 -   Components
 -   Brief description
--   Applicable Agent Versions
+-   Applicable Alloy versions
 -   Declare arguments and exports
 -   Example
 


### PR DESCRIPTION
* Dynamically switch between the light/dark Alloy logo on README.md depending on the GitHub theme 
* Rename old references to Flow/Agent 
* Remove reference to "modules classic" which doesn't exist in Alloy