### PR TITLE
docs: update usage example to reflect new repo layout

### DIFF
--- a/modules/cloud/grafana/cloud/README.md
+++ b/modules/cloud/grafana/cloud/README.md
@@ -50,7 +50,7 @@ The token must have permissions to read stack information. The setup of these pe
 ### `stack`
 
 ```river
-import.git "grafana_cloud" {
+module.git "grafana_cloud" {
   repository = "https://github.com/grafana/alloy-modules.git"
   revision = "main"
   path = "modules/cloud/grafana/cloud/module.river"

--- a/modules/cloud/grafana/cloud/README.md
+++ b/modules/cloud/grafana/cloud/README.md
@@ -50,10 +50,10 @@ The token must have permissions to read stack information. The setup of these pe
 ### `stack`
 
 ```river
-module.git "grafana_cloud" {
+import.git "grafana_cloud" {
   repository = "https://github.com/grafana/alloy-modules.git"
   revision = "main"
-  path = "modules/cloud/grafana/cloud/module.river"
+  path = "modules/cloud/grafana/cloud/module.alloy"
   pull_frequency = "15m"
 }
 

--- a/modules/cloud/grafana/cloud/README.md
+++ b/modules/cloud/grafana/cloud/README.md
@@ -1,5 +1,10 @@
 # Grafana Cloud Auto-Configuration Module
 
+> [!WARNING]
+> Currently, the Pyroscope functionality in this module is under the `public-preview` stability level. As such, to use this module, you will need to pass `--stability.level=public-preview` to your `alloy run` command.
+>
+> See the docs for [`pyroscope.write`](https://grafana.com/docs/alloy/latest/reference/components/pyroscope.write/) and [Grafana Labs' Release Lifecycle](https://grafana.com/docs/release-life-cycle/) for more info on this.
+
 Module to interact with Grafana Cloud.
 
 ## Components

--- a/modules/cloud/grafana/cloud/README.md
+++ b/modules/cloud/grafana/cloud/README.md
@@ -46,15 +46,15 @@ The token must have permissions to read stack information. The setup of these pe
 
 ```river
 import.git "grafana_cloud" {
-  repository = "https://github.com/grafana/flow-modules.git"
+  repository = "https://github.com/grafana/alloy-modules.git"
   revision = "main"
-  path = "modules/cloud/grafana.river"
+  path = "modules/cloud/grafana/cloud/module.river"
   pull_frequency = "15m"
 }
 
 // get the receivers
 grafana_cloud.stack "receivers" {
-  stack = "DashyMcDashFace"
+  stack_name = "DashyMcDashFace"
   token = "XXXXXXXXXXXXX"
 }
 


### PR DESCRIPTION
## Changes

- Updates references to old `flow-modules` repo
- Updates file path for `path` argument to `module.git`
- Updates `stack` argument to `stack_name`
- Updates syntax to match how Alloy works instead of Flow mode
- Adds warning about the module requiring `--stability.level=public-preview` to use the module due to `pyroscope.*` being `public-preview` stability.