### PR TITLE
fix argument name for ipv6 masking

### DIFF
--- a/modules/kubernetes/annotations/logs/mask.alloy
+++ b/modules/kubernetes/annotations/logs/mask.alloy
@@ -288,7 +288,7 @@ declare "mask_ipv6" {
     optional = true
   }
 
-  argument "mask_ipv4_value" {
+  argument "mask_ipv6_value" {
     comment = "The regular expression to use to determine if logs should have IPv6 values masked, if you want to mask IPv6 values by default without setting the annotations everywhere use '.*' or 'true|' (default: true)"
     default = "(?i)true"
     optional = true


### PR DESCRIPTION
running the code without this rename causes alloy to stop during config loading. Line 327 expects the argument name "mask_ipv6_value".

Tested the fix locally and it worked for me.