### PR TITLE
Kube annotations scrape fixes

### DIFF
--- a/modules/kubernetes/annotations/README.md
+++ b/modules/kubernetes/annotations/README.md
@@ -288,7 +288,7 @@ The following example will scrape all metric annotation instances in cluster.
 
 ```alloy
 import.git "metric_annotations" {
-  repository = "https://github.com/grafana/flow-modules.git"
+  repository = "https://github.com/grafana/alloy-modules.git"
   revision = "main"
   path = "modules/kubernetes/annotations/metrics.alloy"
   pull_frequency = "15m"
@@ -300,7 +300,7 @@ metric_annotations.kubernetes "targets" {
 }
 
 // scrape the annotations
-metric_annotations.scrape "metrics" {
+metric_annotations.metrics "scrape" {
   targets = metric_annotations.kubernetes.targets.output
   forward_to = [
     prometheus.remote_write.default.receiver,
@@ -326,7 +326,7 @@ The following example will scrape all probe annotation instances in cluster.
 
 ```alloy
 import.git "probe_annotations" {
-  repository = "https://github.com/grafana/flow-modules.git"
+  repository = "https://github.com/grafana/alloy-modules.git"
   revision = "main"
   path = "modules/kubernetes/annotations/probes.alloy"
   pull_frequency = "15m"
@@ -338,7 +338,7 @@ probe_annotations.kubernetes "targets" {
 }
 
 // scrape the annotations
-probe_annotations.scrape "probes" {
+probe_annotations.probe "scrape" {
   targets = probe_annotations.kubernetes.targets.output
   forward_to = [
     prometheus.remote_write.default.receiver,

--- a/modules/kubernetes/annotations/README.md
+++ b/modules/kubernetes/annotations/README.md
@@ -239,6 +239,8 @@ Handles discovery of kubernetes targets and exports them, this component does no
 | `label_selectors` | _no_     | `[]`                  | The [label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) to use to find matching targets                                                                                                                                                                                                                                                       |
 | `annotation`      | _no_     | `metrics.grafana.com` | The domain to use when looking for annotations, Kubernetes selectors do not support a logical `OR`, if multiple types of annotations are needed, this module should be invoked multiple times.                                                                                                                                                                                         |
 | `tenant`          | _no_     | `.*`                  | The tenant to write metrics to.  This does not have to be the tenantId, this is the value to look for in the `{{argument.annotation.value}}/tenant` annotation i.e. (`metrics.grafana.com/tenant`), and this can be a regular expression.  It is recommended to use a default i.e. `primary\|`, which would match the primary tenant or an empty string meaning the tenant is not set. |
+| `scrape_interval` | _no_     | `60s`                 | How often to scrape metrics from the targets                                                                                                                                                                                                                                                                                                                                           |
+| `scrape_timeout`  | _no_     | `10s`                 | How long before a scrape times out                                                                                                                                                                                                                                                                                                                                                     |
 | `blackbox_url`    | _no_     | `""`                  | The address of the blackbox exporter to use (without the protocol), only the hostname and port i.e. `blackbox-prometheus-blackbox-exporter.default.svc.cluster.local:9115`                                                                                                                                                                                                             |
 
 #### Exports
@@ -263,16 +265,14 @@ The following labels are automatically added to exported targets.
 
 #### Arguments
 
-| Name              | Required | Default                       | Description                                                                                                                                         |
-| :---------------- | :------- | :---------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `targets`         | _yes_    | `list(map(string))`           | List of targets to scrape                                                                                                                           |
-| `forward_to`      | _yes_    | `list(MetricsReceiver)`       | Must be a where scraped should be forwarded to                                                                                                      |
-| `keep_metrics`    | _no_     | [see code](module.alloy#L228) | A regular expression of metrics to keep                                                                                                             |
-| `drop_metrics`    | _no_     | [see code](module.alloy#L235) | A regular expression of metrics to drop                                                                                                             |
-| `scrape_interval` | _no_     | `60s`                         | How often to scrape metrics from the targets                                                                                                        |
-| `scrape_timeout`  | _no_     | `10s`                         | How long before a scrape times out                                                                                                                  |
-| `max_cache_size`  | _no_     | `100000`                      | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
-| `clustering`      | _no_     | `false`                       | Whether or not [clustering](https://grafana.com/docs/agent/latest/flow/concepts/clustering/) should be enabled                                      |
+| Name             | Required | Default                       | Description                                                                                                                                         |
+| :--------------- | :------- | :---------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `targets`        | _yes_    | `list(map(string))`           | List of targets to scrape                                                                                                                           |
+| `forward_to`     | _yes_    | `list(MetricsReceiver)`       | Must be a where scraped should be forwarded to                                                                                                      |
+| `keep_metrics`   | _no_     | [see code](module.alloy#L228) | A regular expression of metrics to keep                                                                                                             |
+| `drop_metrics`   | _no_     | [see code](module.alloy#L235) | A regular expression of metrics to drop                                                                                                             |
+| `max_cache_size` | _no_     | `100000`                      | The maximum number of elements to hold in the relabeling cache.  This should be at least 2x-5x your largest scrape target or samples appended rate. |
+| `clustering`     | _no_     | `false`                       | Whether or not [clustering](https://grafana.com/docs/agent/latest/flow/concepts/clustering/) should be enabled                                      |
 
 #### Labels
 

--- a/modules/kubernetes/annotations/metrics.alloy
+++ b/modules/kubernetes/annotations/metrics.alloy
@@ -128,6 +128,16 @@ declare "kubernetes" {
     default = false
   }
 
+  argument "scrape_interval" {
+    comment = "How often to scrape metrics from the targets (default: 60s)"
+    optional = true
+  }
+
+  argument "scrape_timeout" {
+    comment = "How long before a scrape times out (default: 10s)"
+    optional = true
+  }
+
   /*
     Hidden Arguments
     These arguments are used to set reusable variables to avoid repeating logic
@@ -500,16 +510,6 @@ declare "metrics" {
 
   argument "drop_metrics" {
     comment = "A regex of metrics to drop (default: \"\")"
-    optional = true
-  }
-
-  argument "scrape_interval" {
-    comment = "How often to scrape metrics from the targets (default: 60s)"
-    optional = true
-  }
-
-  argument "scrape_timeout" {
-    comment = "How long before a scrape times out (default: 10s)"
     optional = true
   }
 

--- a/modules/kubernetes/annotations/metrics.alloy
+++ b/modules/kubernetes/annotations/metrics.alloy
@@ -541,8 +541,6 @@ declare "metrics" {
     forward_to = [prometheus.relabel.annotations.receiver]
     targets = discovery.relabel.http_annotations.output
     scheme = "http"
-    scrape_interval = coalesce(argument.scrape_interval.value, "60s")
-    scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
 
     clustering {
       enabled = coalesce(argument.clustering.value, false)
@@ -566,8 +564,6 @@ declare "metrics" {
     forward_to = [prometheus.relabel.annotations.receiver]
     targets = discovery.relabel.https_annotations.output
     scheme = "https"
-    scrape_interval = coalesce(argument.scrape_interval.value, "60s")
-    scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
     bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
     tls_config {


### PR DESCRIPTION
Problem: kubernetes/annotations/metrics.alloy won't load because the `kubernetes` discovery/relabel component references `scrape_timeout` and `scrape_interval`, which are not declared.

I think this is the intended solution to this. The `scrape_timeout` and `scrape_interval` should be set in the `kubernetes` section so that they are able to be replaced if a service sets the label to override. The `scrape_timeout` and `scrape_interval` should be removed from the `prometheus.scrape` components of the `metrics` section, so that both values can be set by the `__scrape_timeout__` and `__scrape_interval__` labels respectively, which should be set during discovery/relabel to either the default, the passed argument, or the overriding kube label.

Notated the same in the readme as well as fixed some incorrect references. I did verify this change in a running cluster by both setting an argument as well as setting a service label.