### PR TITLE
change default port name from 'metrics' to 'http-metrics'

### DIFF
--- a/modules/databases/timeseries/loki/metrics.alloy
+++ b/modules/databases/timeseries/loki/metrics.alloy
@@ -59,7 +59,7 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
       action = "keep"
     }
 


### PR DESCRIPTION
Updates the default port name in the Loki Module from `metrics` to `http-metrics`