### PR TITLE
change all metrics.alloy to drop init container in separate step

### DIFF
--- a/modules/broker/rabbitmq/metrics.alloy
+++ b/modules/broker/rabbitmq/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "rabbitmq-exporter") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "rabbitmq-exporter") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/collector/agent/metrics.alloy
+++ b/modules/collector/agent/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/kv/etcd/metrics.alloy
+++ b/modules/databases/kv/etcd/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/kv/memcached/metrics.alloy
+++ b/modules/databases/kv/memcached/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/kv/redis/metrics.alloy
+++ b/modules/databases/kv/redis/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "redis-exporter") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "redis-exporter") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/sql/mysql/metrics.alloy
+++ b/modules/databases/sql/mysql/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "mysql-exporter") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "mysql-exporter") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/sql/postgres/metrics.alloy
+++ b/modules/databases/sql/postgres/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "postgres-exporter") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "postgres-exporter") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/timeseries/loki/metrics.alloy
+++ b/modules/databases/timeseries/loki/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/timeseries/mimir/metrics.alloy
+++ b/modules/databases/timeseries/mimir/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/timeseries/pyroscope/metrics.alloy
+++ b/modules/databases/timeseries/pyroscope/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/timeseries/tempo/metrics.alloy
+++ b/modules/databases/timeseries/tempo/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/kubernetes/cert-manager/metrics.alloy
+++ b/modules/kubernetes/cert-manager/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
       regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/kubernetes/core/metrics.alloy
+++ b/modules/kubernetes/core/metrics.alloy
@@ -925,11 +925,17 @@ declare "kube_dns" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/kubernetes/konnectivity-agent/metrics.alloy
+++ b/modules/kubernetes/konnectivity-agent/metrics.alloy
@@ -57,11 +57,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/networking/consul/metrics.alloy
+++ b/modules/networking/consul/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/networking/haproxy/metrics.alloy
+++ b/modules/networking/haproxy/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "prometheus") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "prometheus") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/system/node-exporter/metrics.alloy
+++ b/modules/system/node-exporter/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/ui/grafana/metrics.alloy
+++ b/modules/ui/grafana/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "grafana") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "grafana") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label


### PR DESCRIPTION
I have had issues where a container is inadvertently dropped because it does not have the label `__meta_kubernetes_pod_container_init` at all. The keep step is looking for the label to be present and set to `false`. Instead, I moved this check out to its own rule to drop if the label is set to `true`. This clears up the false drops, but still keeps the intention of the original step to not scrape init pods.

I originally had this issue with the `kube_dns` relabel in `kubernetes/core/metrics.alloy` and was able to resolve and test this fix. I went through and updated any `metrics.alloy` that had this pattern with the assumption that it should also be fixed in those as well.