### PR TITLE
fix cert-manager port name is http-metrics

### DIFF
--- a/modules/kubernetes/cert-manager/metrics.alloy
+++ b/modules/kubernetes/cert-manager/metrics.alloy
@@ -59,7 +59,7 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
       action = "keep"
     }
 


### PR DESCRIPTION
Cert manager is using the wrong default port name. Should be `http-metrics`. This PR assumes that #40 is also resolved as it removes the init-container status from the same line.