### PR TITLE
Fix annotation scraping - scrape_port_named_metrics and metrics.grafana.com/port

### DIFF
--- a/modules/broker/rabbitmq/metrics.alloy
+++ b/modules/broker/rabbitmq/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-rabbitmq-exporter"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-rabbitmq-exporter"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9419")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9419")),
         "source" = "local",
       },
     ]

--- a/modules/collector/agent/metrics.alloy
+++ b/modules/collector/agent/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=grafana-agent"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=grafana-agent"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "12345")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "12345")),
         "source" = "local",
       },
     ]

--- a/modules/collector/push-gateway/metrics.alloy
+++ b/modules/collector/push-gateway/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "service"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-pushgateway"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-pushgateway"]), ",")
     }
 
     namespaces {

--- a/modules/databases/kv/etcd/metrics.alloy
+++ b/modules/databases/kv/etcd/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/component=etcd"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/component=etcd"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9150")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9150")),
         "source" = "local",
       },
     ]

--- a/modules/databases/kv/memcached/metrics.alloy
+++ b/modules/databases/kv/memcached/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=memcached"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=memcached"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9150")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9150")),
         "source" = "local",
       },
     ]

--- a/modules/databases/kv/redis/metrics.alloy
+++ b/modules/databases/kv/redis/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-redis-exporter"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-redis-exporter"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9150")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9150")),
         "source" = "local",
       },
     ]

--- a/modules/databases/sql/mysql/metrics.alloy
+++ b/modules/databases/sql/mysql/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-mysql-exporter"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-mysql-exporter"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9104")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9104")),
         "source" = "local",
       },
     ]

--- a/modules/databases/sql/postgres/metrics.alloy
+++ b/modules/databases/sql/postgres/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-postgres-exporter"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-postgres-exporter"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9187")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9187")),
         "source" = "local",
       },
     ]

--- a/modules/databases/timeseries/loki/metrics.alloy
+++ b/modules/databases/timeseries/loki/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value,  ["app.kubernetes.io/name=loki"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value,  ["app.kubernetes.io/name=loki"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "3000")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "3000")),
         "source" = "local",
       },
     ]

--- a/modules/databases/timeseries/mimir/metrics.alloy
+++ b/modules/databases/timeseries/mimir/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=mimir"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=mimir"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "8080")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "8080")),
         "source" = "local",
       },
     ]

--- a/modules/databases/timeseries/pyroscope/metrics.alloy
+++ b/modules/databases/timeseries/pyroscope/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=pyroscope"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=pyroscope"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "4040")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "4040")),
         "source" = "local",
       },
     ]

--- a/modules/databases/timeseries/tempo/metrics.alloy
+++ b/modules/databases/timeseries/tempo/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=tempo"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=tempo"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "3200")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "3200")),
         "source" = "local",
       },
     ]

--- a/modules/kubernetes/annotations/logs/README.md
+++ b/modules/kubernetes/annotations/logs/README.md
@@ -475,18 +475,18 @@ log_utils.post_process_metrics "default" {}
 
 loki.write "local" {
   endpoint {
-    url = env("LOGS_PRIMARY_URL")
+    url = sys.env("LOGS_PRIMARY_URL")
 
     basic_auth {
-      username = env("LOGS_PRIMARY_TENANT")
-      password = env("LOGS_PRIMARY_TOKEN")
+      username = sys.env("LOGS_PRIMARY_TENANT")
+      password = sys.env("LOGS_PRIMARY_TOKEN")
     }
   }
 
   external_labels = {
-    "cluster" = coalesce(env("CLUSTER_NAME"), env("CLUSTER"), ""),
-    "env" = coalesce(env("ENV"), ""),
-    "region" = coalesce(env("REGION"), ""),
+    "cluster" = coalesce(sys.env("CLUSTER_NAME"), sys.env("CLUSTER"), ""),
+    "env" = coalesce(sys.env("ENV"), ""),
+    "region" = coalesce(sys.env("REGION"), ""),
   }
 }
 ```

--- a/modules/kubernetes/annotations/logs/drop.alloy
+++ b/modules/kubernetes/annotations/logs/drop.alloy
@@ -68,7 +68,7 @@ declare "drop_levels" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {

--- a/modules/kubernetes/annotations/logs/embed.alloy
+++ b/modules/kubernetes/annotations/logs/embed.alloy
@@ -39,7 +39,7 @@ declare "embed_pod" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {

--- a/modules/kubernetes/annotations/logs/json.alloy
+++ b/modules/kubernetes/annotations/logs/json.alloy
@@ -32,7 +32,7 @@ declare "json_scrub_empties" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -99,7 +99,7 @@ declare "json_scrub_nulls" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {

--- a/modules/kubernetes/annotations/logs/logs.alloy
+++ b/modules/kubernetes/annotations/logs/logs.alloy
@@ -46,7 +46,7 @@ declare "pods" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   // export the discovered targets
@@ -65,8 +65,8 @@ declare "pods" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
 
     namespaces {

--- a/modules/kubernetes/annotations/logs/mask.alloy
+++ b/modules/kubernetes/annotations/logs/mask.alloy
@@ -42,7 +42,7 @@ declare "mask_luhn" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -106,7 +106,7 @@ declare "mask_credit_card" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -177,7 +177,7 @@ declare "mask_email" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -242,7 +242,7 @@ declare "mask_ipv4" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -307,7 +307,7 @@ declare "mask_ipv6" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -372,7 +372,7 @@ declare "mask_phone" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -437,7 +437,7 @@ declare "mask_ssn" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {

--- a/modules/kubernetes/annotations/logs/utils.alloy
+++ b/modules/kubernetes/annotations/logs/utils.alloy
@@ -32,7 +32,7 @@ declare "decolorize" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -91,7 +91,7 @@ declare "trim" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -156,7 +156,7 @@ declare "dedup_spaces" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -230,7 +230,7 @@ declare "sampling" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {

--- a/modules/kubernetes/annotations/metrics.alloy
+++ b/modules/kubernetes/annotations/metrics.alloy
@@ -188,11 +188,6 @@ declare "kubernetes" {
     // the label prometheus.io/service-monitor: "false" is a common label for headless services, when performing endpoint
     // service discovery, if there is both a load-balanced service and headless service, this can result in duplicate
     // scrapes if the name of the service is attached as a label.  any targets with this label or annotation set should be dropped
-    rule {
-      action = "replace"
-      replacement = "false"
-      target_label = "__tmp_scrape"
-    }
 
     rule {
       action = "replace"
@@ -202,9 +197,9 @@ declare "kubernetes" {
         "__meta_kubernetes_" + argument.role.value + "_label_prometheus_io_service_monitor",
       ]
       separator = ";"
-      // only allow empty or true, otherwise defaults to false
-      regex = "^(?:;*)?(true)(;|true)*$"
-      replacement = "$1"
+      // set to false if any of the endpoint or service annotations are scrape: false
+      regex = "^.*(?i)(false).*$"
+      replacement = "false"
       target_label = "__tmp_scrape"
     }
 

--- a/modules/kubernetes/annotations/metrics.alloy
+++ b/modules/kubernetes/annotations/metrics.alloy
@@ -297,7 +297,7 @@ declare "kubernetes" {
         "__meta_kubernetes_" + argument.__service_role.value + "_annotation_" + argument.__sd_annotation.value + "_port",
       ]
       separator = ";"
-      regex = "^([^:]+)(?::\\d+)?;(\\d+)$"
+      regex = "^([^:]+)(?::\\d+)?(?:;+(\\d+);*(?:;\\d+)*)$"
       replacement = "$1:$2"
       target_label = "__address__"
     }

--- a/modules/kubernetes/annotations/metrics.alloy
+++ b/modules/kubernetes/annotations/metrics.alloy
@@ -145,19 +145,19 @@ declare "kubernetes" {
   argument "__pod_role" {
     comment = "Most annotation targets service or pod that is all you want, however if the role is endpoints you want the pod"
     optional = true
-    default = replace(coalesce(argument.role.value, "endpoints"), "endpoints", "pod")
+    default = string.replace(coalesce(argument.role.value, "endpoints"), "endpoints", "pod")
   }
 
   argument "__service_role" {
     comment = "Most annotation targets service or pod that is all you want, however if the role is endpoints you we also want to consider service annotations"
     optional = true
-    default = replace(coalesce(argument.role.value, "endpoints"), "endpoints", "service")
+    default = string.replace(coalesce(argument.role.value, "endpoints"), "endpoints", "service")
   }
 
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "metrics.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "metrics.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   // annotations service discovery
@@ -166,8 +166,8 @@ declare "kubernetes" {
 
     selectors {
       role = coalesce(argument.role.value, "endpoints")
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
 
     namespaces {
@@ -210,7 +210,7 @@ declare "kubernetes" {
 
     // add a __tmp_scrape_port_named_metrics from the argument.scrape_port_named_metrics
     rule {
-      replacement = format("%t", argument.scrape_port_named_metrics.value)
+      replacement = string.format("%t", argument.scrape_port_named_metrics.value)
       target_label = "__tmp_scrape_port_named_metrics"
     }
 
@@ -221,7 +221,7 @@ declare "kubernetes" {
         "__tmp_scrape",
         "__tmp_scrape_port_named_metrics",
         // endpoints is the role and most meta labels started with "endpoints", however the port name is an exception and starts with "endpoint"
-        "__meta_kubernetes_" + replace(coalesce(argument.role.value, "endpoints"), "endpoints", "endpoint") + "_port_name",
+        "__meta_kubernetes_" + string.replace(coalesce(argument.role.value, "endpoints"), "endpoints", "endpoint") + "_port_name",
       ]
       separator = ";"
       regex = "^(true;.*|(|true);true;(.*metrics.*))$"

--- a/modules/kubernetes/annotations/probes.alloy
+++ b/modules/kubernetes/annotations/probes.alloy
@@ -108,7 +108,7 @@ declare "kubernetes" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "probes.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "probes.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   // annotations service discovery
@@ -117,8 +117,8 @@ declare "kubernetes" {
 
     selectors {
       role = coalesce(argument.role.value, "service")
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
 
     namespaces {

--- a/modules/kubernetes/cert-manager/metrics.alloy
+++ b/modules/kubernetes/cert-manager/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=cert-manager"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=cert-manager"]), ",")
     }
 
     namespaces {

--- a/modules/kubernetes/core/metrics.alloy
+++ b/modules/kubernetes/core/metrics.alloy
@@ -61,8 +61,8 @@ declare "cadvisor" {
 
     selectors {
       role = "node"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
   }
 
@@ -280,8 +280,8 @@ declare "resources" {
 
     selectors {
       role = "node"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
   }
 
@@ -427,8 +427,8 @@ declare "kubelet" {
 
     selectors {
       role = "node"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
   }
 
@@ -588,8 +588,8 @@ declare "apiserver" {
 
     selectors {
       role = "service"
-      field = join(coalesce(argument.field_selectors.value, ["metadata.name=kubernetes"]), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, ["metadata.name=kubernetes"]), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
 
     namespaces {
@@ -750,8 +750,8 @@ declare "probes" {
 
     selectors {
       role = "node"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
   }
 
@@ -906,8 +906,8 @@ declare "kube_dns" {
 
     selectors {
       role = "endpoints"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["k8s-app=kube-dns"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["k8s-app=kube-dns"]), ",")
     }
 
     namespaces {

--- a/modules/kubernetes/konnectivity-agent/metrics.alloy
+++ b/modules/kubernetes/konnectivity-agent/metrics.alloy
@@ -38,8 +38,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["k8s-app=konnectivity-agent"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["k8s-app=konnectivity-agent"]), ",")
     }
 
     namespaces {

--- a/modules/kubernetes/kube-state-metrics/metrics.alloy
+++ b/modules/kubernetes/kube-state-metrics/metrics.alloy
@@ -39,8 +39,8 @@ declare "kubernetes" {
 
     selectors {
       role = "service"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=kube-state-metrics"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=kube-state-metrics"]), ",")
     }
 
     namespaces {

--- a/modules/kubernetes/opencost/metrics.alloy
+++ b/modules/kubernetes/opencost/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "service"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=opencost"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=opencost"]), ",")
     }
 
     namespaces {

--- a/modules/networking/consul/metrics.alloy
+++ b/modules/networking/consul/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app=consul"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app=consul"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9150")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9150")),
         "source" = "local",
       },
     ]

--- a/modules/networking/haproxy/metrics.alloy
+++ b/modules/networking/haproxy/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/component=haproxy"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/component=haproxy"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "8405")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "8405")),
         "source" = "local",
       },
     ]

--- a/modules/source-control/gitlab/metrics.alloy
+++ b/modules/source-control/gitlab/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "service"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=gitlab-ci-pipelines-exporter"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=gitlab-ci-pipelines-exporter"]), ",")
     }
 
     namespaces {
@@ -119,7 +119,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9168")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9168")),
         "source" = "local",
       },
     ]

--- a/modules/system/node-exporter/metrics.alloy
+++ b/modules/system/node-exporter/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-node-exporter"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-node-exporter"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9100")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9100")),
         "source" = "local",
       },
     ]

--- a/modules/ui/grafana/metrics.alloy
+++ b/modules/ui/grafana/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=grafana"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=grafana"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "3000")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "3000")),
         "source" = "local",
       },
     ]


### PR DESCRIPTION
2 fixes in modules/kubernetes/annotations/metrics.alloy

- In one of the first steps, `__tmp_scrape` is default set to `false`, but the next step watches for `metrics.grafana.com/scrape` to be blank or `true` and then makes the value of `__tmp_scrape` = `true`. So `__tmp_scrape` would never be blank. But the step that runs if the attribute `scrape_port_named_metrics` = `true` only runs if `__tmp_scrape` is true or blank. The point of that attribute is to scrape any port that contains the word `metrics` in its name, regardless of the `metrics.grafana.com/scrape` attribute, but it was not working that way since it could never be blank.
- The step that watches for `metrics.grafana.com/port` to be set to override the `__address__` port had an additional source label added to it when it was copied from grafana-agent-modules, but the regex was not adjusted to account for the additional label, so the step would never work.