### PR TITLE
feat: Custom job label

### DIFF
--- a/modules/broker/rabbitmq/metrics.alloy
+++ b/modules/broker/rabbitmq/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-rabbitmq-exporter"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-rabbitmq-exporter"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9419")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9419")),
         "source" = "local",
       },
     ]

--- a/modules/broker/rabbitmq/metrics.alloy
+++ b/modules/broker/rabbitmq/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "rabbitmq-exporter") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "rabbitmq-exporter") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/collector/agent/metrics.alloy
+++ b/modules/collector/agent/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=grafana-agent"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=grafana-agent"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "12345")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "12345")),
         "source" = "local",
       },
     ]

--- a/modules/collector/agent/metrics.alloy
+++ b/modules/collector/agent/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/collector/push-gateway/metrics.alloy
+++ b/modules/collector/push-gateway/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "service"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-pushgateway"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-pushgateway"]), ",")
     }
 
     namespaces {

--- a/modules/databases/kv/etcd/metrics.alloy
+++ b/modules/databases/kv/etcd/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/kv/etcd/metrics.alloy
+++ b/modules/databases/kv/etcd/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/component=etcd"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/component=etcd"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9150")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9150")),
         "source" = "local",
       },
     ]

--- a/modules/databases/kv/memcached/metrics.alloy
+++ b/modules/databases/kv/memcached/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=memcached"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=memcached"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9150")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9150")),
         "source" = "local",
       },
     ]

--- a/modules/databases/kv/memcached/metrics.alloy
+++ b/modules/databases/kv/memcached/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/kv/redis/metrics.alloy
+++ b/modules/databases/kv/redis/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "redis-exporter") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "redis-exporter") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/kv/redis/metrics.alloy
+++ b/modules/databases/kv/redis/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-redis-exporter"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-redis-exporter"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9150")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9150")),
         "source" = "local",
       },
     ]

--- a/modules/databases/sql/mysql/metrics.alloy
+++ b/modules/databases/sql/mysql/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-mysql-exporter"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-mysql-exporter"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9104")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9104")),
         "source" = "local",
       },
     ]

--- a/modules/databases/sql/mysql/metrics.alloy
+++ b/modules/databases/sql/mysql/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "mysql-exporter") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "mysql-exporter") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/sql/postgres/metrics.alloy
+++ b/modules/databases/sql/postgres/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "postgres-exporter") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "postgres-exporter") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/sql/postgres/metrics.alloy
+++ b/modules/databases/sql/postgres/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-postgres-exporter"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-postgres-exporter"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9187")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9187")),
         "source" = "local",
       },
     ]

--- a/modules/databases/timeseries/loki/metrics.alloy
+++ b/modules/databases/timeseries/loki/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value,  ["app.kubernetes.io/name=loki"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value,  ["app.kubernetes.io/name=loki"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "3000")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "3000")),
         "source" = "local",
       },
     ]

--- a/modules/databases/timeseries/loki/metrics.alloy
+++ b/modules/databases/timeseries/loki/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/timeseries/mimir/metrics.alloy
+++ b/modules/databases/timeseries/mimir/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/timeseries/mimir/metrics.alloy
+++ b/modules/databases/timeseries/mimir/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=mimir"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=mimir"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "8080")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "8080")),
         "source" = "local",
       },
     ]

--- a/modules/databases/timeseries/pyroscope/metrics.alloy
+++ b/modules/databases/timeseries/pyroscope/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=pyroscope"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=pyroscope"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "4040")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "4040")),
         "source" = "local",
       },
     ]

--- a/modules/databases/timeseries/pyroscope/metrics.alloy
+++ b/modules/databases/timeseries/pyroscope/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/databases/timeseries/tempo/metrics.alloy
+++ b/modules/databases/timeseries/tempo/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=tempo"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=tempo"]), ",")
     }
 
     namespaces {
@@ -154,7 +154,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "3200")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "3200")),
         "source" = "local",
       },
     ]

--- a/modules/databases/timeseries/tempo/metrics.alloy
+++ b/modules/databases/timeseries/tempo/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/kubernetes/annotations/logs/README.md
+++ b/modules/kubernetes/annotations/logs/README.md
@@ -427,10 +427,37 @@ log_annotations.decolorize "default" {
   annotation = "logs.grafana.com"
 }
 
+// set default level and log_type to unknown
 log_utils.default_level "default" {
+  forward_to = [log_utils.klog_format.default.receiver]
+}
+
+// identify klog format and parse log level
+log_utils.klog_format "default" {
+  forward_to = [log_utils.zerolog_format.default.receiver]
+}
+
+// identify zerolog format and parse log level
+log_utils.zerolog_format "default" {
+  forward_to = [log_utils.json_format.default.receiver]
+}
+
+// identify json format and parse log level
+log_utils.json_format "default" {
+  forward_to = [log_utils.logfmt_format.default.receiver]
+}
+
+// identify logfmt format and parse log level
+log_utils.logfmt_format "default" {
+  forward_to = [log_utils.unknown_format.default.receiver]
+}
+
+// attempt parse log level from unidentified log type
+log_utils.unknown_format "default" {
   forward_to = [log_utils.normalize_level.default.receiver]
 }
 
+// Set level consistently (case and name)
 log_utils.normalize_level "default" {
   forward_to = [
     log_utils.pre_process_metrics.default.receiver,

--- a/modules/kubernetes/annotations/logs/README.md
+++ b/modules/kubernetes/annotations/logs/README.md
@@ -502,18 +502,18 @@ log_utils.post_process_metrics "default" {}
 
 loki.write "local" {
   endpoint {
-    url = env("LOGS_PRIMARY_URL")
+    url = sys.env("LOGS_PRIMARY_URL")
 
     basic_auth {
-      username = env("LOGS_PRIMARY_TENANT")
-      password = env("LOGS_PRIMARY_TOKEN")
+      username = sys.env("LOGS_PRIMARY_TENANT")
+      password = sys.env("LOGS_PRIMARY_TOKEN")
     }
   }
 
   external_labels = {
-    "cluster" = coalesce(env("CLUSTER_NAME"), env("CLUSTER"), ""),
-    "env" = coalesce(env("ENV"), ""),
-    "region" = coalesce(env("REGION"), ""),
+    "cluster" = coalesce(sys.env("CLUSTER_NAME"), sys.env("CLUSTER"), ""),
+    "env" = coalesce(sys.env("ENV"), ""),
+    "region" = coalesce(sys.env("REGION"), ""),
   }
 }
 ```

--- a/modules/kubernetes/annotations/logs/drop.alloy
+++ b/modules/kubernetes/annotations/logs/drop.alloy
@@ -68,7 +68,7 @@ declare "drop_levels" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {

--- a/modules/kubernetes/annotations/logs/embed.alloy
+++ b/modules/kubernetes/annotations/logs/embed.alloy
@@ -39,7 +39,7 @@ declare "embed_pod" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {

--- a/modules/kubernetes/annotations/logs/json.alloy
+++ b/modules/kubernetes/annotations/logs/json.alloy
@@ -32,7 +32,7 @@ declare "json_scrub_empties" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -99,7 +99,7 @@ declare "json_scrub_nulls" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {

--- a/modules/kubernetes/annotations/logs/logs.alloy
+++ b/modules/kubernetes/annotations/logs/logs.alloy
@@ -39,6 +39,12 @@ declare "pods" {
     default = ".*"
   }
 
+  argument "job_format" {
+    comment = "Format of the job label. Default is namespace/pod name as $1/$2"
+    optional = true
+    default = "$1/$2"
+  }
+
   /*
     Hidden Arguments
     These arguments are used to set reusable variables to avoid repeating logic
@@ -190,11 +196,11 @@ declare "pods" {
     rule {
       action = "replace"
       source_labels = [
-        "workload",
         "__meta_kubernetes_namespace",
+        "workload",
       ]
-      regex = ".+\\/(.+);(.+)"
-      replacement = "$2/$1"
+      regex = "(.+);.+\\/(.+)"
+      replacement = argument.job_format.value
       target_label = "job"
     }
   }

--- a/modules/kubernetes/annotations/logs/logs.alloy
+++ b/modules/kubernetes/annotations/logs/logs.alloy
@@ -46,7 +46,7 @@ declare "pods" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   // export the discovered targets
@@ -65,8 +65,8 @@ declare "pods" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
 
     namespaces {

--- a/modules/kubernetes/annotations/logs/mask.alloy
+++ b/modules/kubernetes/annotations/logs/mask.alloy
@@ -42,7 +42,7 @@ declare "mask_luhn" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -106,7 +106,7 @@ declare "mask_credit_card" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -177,7 +177,7 @@ declare "mask_email" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -242,7 +242,7 @@ declare "mask_ipv4" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -307,7 +307,7 @@ declare "mask_ipv6" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -372,7 +372,7 @@ declare "mask_phone" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -437,7 +437,7 @@ declare "mask_ssn" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {

--- a/modules/kubernetes/annotations/logs/utils.alloy
+++ b/modules/kubernetes/annotations/logs/utils.alloy
@@ -32,7 +32,7 @@ declare "decolorize" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -91,7 +91,7 @@ declare "trim" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -156,7 +156,7 @@ declare "dedup_spaces" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {
@@ -230,7 +230,7 @@ declare "sampling" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "logs.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   export "annotation" {

--- a/modules/kubernetes/annotations/metrics.alloy
+++ b/modules/kubernetes/annotations/metrics.alloy
@@ -188,11 +188,6 @@ declare "kubernetes" {
     // the label prometheus.io/service-monitor: "false" is a common label for headless services, when performing endpoint
     // service discovery, if there is both a load-balanced service and headless service, this can result in duplicate
     // scrapes if the name of the service is attached as a label.  any targets with this label or annotation set should be dropped
-    rule {
-      action = "replace"
-      replacement = "false"
-      target_label = "__tmp_scrape"
-    }
 
     rule {
       action = "replace"
@@ -202,9 +197,9 @@ declare "kubernetes" {
         "__meta_kubernetes_" + argument.role.value + "_label_prometheus_io_service_monitor",
       ]
       separator = ";"
-      // only allow empty or true, otherwise defaults to false
-      regex = "^(?:;*)?(true)(;|true)*$"
-      replacement = "$1"
+      // set to false if any of the endpoint or service annotations are scrape: false
+      regex = "^.*(?i)(false).*$"
+      replacement = "false"
       target_label = "__tmp_scrape"
     }
 

--- a/modules/kubernetes/annotations/metrics.alloy
+++ b/modules/kubernetes/annotations/metrics.alloy
@@ -297,7 +297,7 @@ declare "kubernetes" {
         "__meta_kubernetes_" + argument.__service_role.value + "_annotation_" + argument.__sd_annotation.value + "_port",
       ]
       separator = ";"
-      regex = "^([^:]+)(?::\\d+)?;(\\d+)$"
+      regex = "^([^:]+)(?::\\d+)?(?:;+(\\d+);*(?:;\\d+)*)$"
       replacement = "$1:$2"
       target_label = "__address__"
     }

--- a/modules/kubernetes/annotations/metrics.alloy
+++ b/modules/kubernetes/annotations/metrics.alloy
@@ -145,19 +145,19 @@ declare "kubernetes" {
   argument "__pod_role" {
     comment = "Most annotation targets service or pod that is all you want, however if the role is endpoints you want the pod"
     optional = true
-    default = replace(coalesce(argument.role.value, "endpoints"), "endpoints", "pod")
+    default = string.replace(coalesce(argument.role.value, "endpoints"), "endpoints", "pod")
   }
 
   argument "__service_role" {
     comment = "Most annotation targets service or pod that is all you want, however if the role is endpoints you we also want to consider service annotations"
     optional = true
-    default = replace(coalesce(argument.role.value, "endpoints"), "endpoints", "service")
+    default = string.replace(coalesce(argument.role.value, "endpoints"), "endpoints", "service")
   }
 
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "metrics.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "metrics.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   // annotations service discovery
@@ -166,8 +166,8 @@ declare "kubernetes" {
 
     selectors {
       role = coalesce(argument.role.value, "endpoints")
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
 
     namespaces {
@@ -210,7 +210,7 @@ declare "kubernetes" {
 
     // add a __tmp_scrape_port_named_metrics from the argument.scrape_port_named_metrics
     rule {
-      replacement = format("%t", argument.scrape_port_named_metrics.value)
+      replacement = string.format("%t", argument.scrape_port_named_metrics.value)
       target_label = "__tmp_scrape_port_named_metrics"
     }
 
@@ -221,7 +221,7 @@ declare "kubernetes" {
         "__tmp_scrape",
         "__tmp_scrape_port_named_metrics",
         // endpoints is the role and most meta labels started with "endpoints", however the port name is an exception and starts with "endpoint"
-        "__meta_kubernetes_" + replace(coalesce(argument.role.value, "endpoints"), "endpoints", "endpoint") + "_port_name",
+        "__meta_kubernetes_" + string.replace(coalesce(argument.role.value, "endpoints"), "endpoints", "endpoint") + "_port_name",
       ]
       separator = ";"
       regex = "^(true;.*|(|true);true;(.*metrics.*))$"

--- a/modules/kubernetes/annotations/metrics.alloy
+++ b/modules/kubernetes/annotations/metrics.alloy
@@ -138,6 +138,12 @@ declare "kubernetes" {
     optional = true
   }
 
+  argument "job_format" {
+    comment = "Format of the job label. Default is namespace/pod_controller_name as $1/$2"
+    optional = true
+    default = "$1/$2"
+  }
+
   /*
     Hidden Arguments
     These arguments are used to set reusable variables to avoid repeating logic
@@ -389,7 +395,7 @@ declare "kubernetes" {
       ]
       separator = ";"
       regex = "^([^;]+)(?:;*)?([^;]+).*$"
-      replacement = "$1/$2"
+      replacement = argument.job_format.value
       target_label = "job"
     }
 
@@ -403,7 +409,7 @@ declare "kubernetes" {
       ]
       separator = ";"
       regex = "^(?:ReplicaSet);([^;]+);([^;]+)-.+$"
-      replacement = "$1/$2"
+      replacement = argument.job_format.value
       target_label = "job"
     }
 

--- a/modules/kubernetes/annotations/probes.alloy
+++ b/modules/kubernetes/annotations/probes.alloy
@@ -108,7 +108,7 @@ declare "kubernetes" {
   argument "__sd_annotation" {
     optional = true
     comment = "The logic is used to transform the annotation argument into a valid label name by removing unsupported characters."
-    default = replace(replace(replace(coalesce(argument.annotation.value, "probes.grafana.com"),".", "_"),"/", "_"),"-", "_")
+    default = string.replace(string.replace(string.replace(coalesce(argument.annotation.value, "probes.grafana.com"),".", "_"),"/", "_"),"-", "_")
   }
 
   // annotations service discovery
@@ -117,8 +117,8 @@ declare "kubernetes" {
 
     selectors {
       role = coalesce(argument.role.value, "service")
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
 
     namespaces {

--- a/modules/kubernetes/cert-manager/metrics.alloy
+++ b/modules/kubernetes/cert-manager/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=cert-manager"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=cert-manager"]), ",")
     }
 
     namespaces {

--- a/modules/kubernetes/cert-manager/metrics.alloy
+++ b/modules/kubernetes/cert-manager/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
       regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/kubernetes/core/metrics.alloy
+++ b/modules/kubernetes/core/metrics.alloy
@@ -925,11 +925,17 @@ declare "kube_dns" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/kubernetes/core/metrics.alloy
+++ b/modules/kubernetes/core/metrics.alloy
@@ -61,8 +61,8 @@ declare "cadvisor" {
 
     selectors {
       role = "node"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
   }
 
@@ -280,8 +280,8 @@ declare "resources" {
 
     selectors {
       role = "node"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
   }
 
@@ -427,8 +427,8 @@ declare "kubelet" {
 
     selectors {
       role = "node"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
   }
 
@@ -588,8 +588,8 @@ declare "apiserver" {
 
     selectors {
       role = "service"
-      field = join(coalesce(argument.field_selectors.value, ["metadata.name=kubernetes"]), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, ["metadata.name=kubernetes"]), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
 
     namespaces {
@@ -750,8 +750,8 @@ declare "probes" {
 
     selectors {
       role = "node"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, []), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, []), ",")
     }
   }
 
@@ -906,8 +906,8 @@ declare "kube_dns" {
 
     selectors {
       role = "endpoints"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["k8s-app=kube-dns"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["k8s-app=kube-dns"]), ",")
     }
 
     namespaces {

--- a/modules/kubernetes/konnectivity-agent/metrics.alloy
+++ b/modules/kubernetes/konnectivity-agent/metrics.alloy
@@ -38,8 +38,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["k8s-app=konnectivity-agent"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["k8s-app=konnectivity-agent"]), ",")
     }
 
     namespaces {

--- a/modules/kubernetes/konnectivity-agent/metrics.alloy
+++ b/modules/kubernetes/konnectivity-agent/metrics.alloy
@@ -57,11 +57,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/kubernetes/kube-state-metrics/metrics.alloy
+++ b/modules/kubernetes/kube-state-metrics/metrics.alloy
@@ -39,8 +39,8 @@ declare "kubernetes" {
 
     selectors {
       role = "service"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=kube-state-metrics"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=kube-state-metrics"]), ",")
     }
 
     namespaces {

--- a/modules/kubernetes/opencost/metrics.alloy
+++ b/modules/kubernetes/opencost/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "service"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=opencost"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=opencost"]), ",")
     }
 
     namespaces {

--- a/modules/networking/consul/metrics.alloy
+++ b/modules/networking/consul/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/networking/consul/metrics.alloy
+++ b/modules/networking/consul/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app=consul"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app=consul"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9150")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9150")),
         "source" = "local",
       },
     ]

--- a/modules/networking/haproxy/metrics.alloy
+++ b/modules/networking/haproxy/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "prometheus") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "prometheus") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/networking/haproxy/metrics.alloy
+++ b/modules/networking/haproxy/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/component=haproxy"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/component=haproxy"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "8405")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "8405")),
         "source" = "local",
       },
     ]

--- a/modules/source-control/gitlab/metrics.alloy
+++ b/modules/source-control/gitlab/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "service"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=gitlab-ci-pipelines-exporter"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=gitlab-ci-pipelines-exporter"]), ",")
     }
 
     namespaces {
@@ -119,7 +119,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9168")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9168")),
         "source" = "local",
       },
     ]

--- a/modules/system/node-exporter/metrics.alloy
+++ b/modules/system/node-exporter/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "metrics") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/system/node-exporter/metrics.alloy
+++ b/modules/system/node-exporter/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-node-exporter"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=prometheus-node-exporter"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "9100")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "9100")),
         "source" = "local",
       },
     ]

--- a/modules/ui/grafana/metrics.alloy
+++ b/modules/ui/grafana/metrics.alloy
@@ -56,11 +56,17 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_container_port_name",
         "__meta_kubernetes_pod_phase",
         "__meta_kubernetes_pod_ready",
-        "__meta_kubernetes_pod_container_init",
       ]
       separator = "@"
-      regex = coalesce(argument.port_name.value, "grafana") + "@Running@true@false"
+      regex = coalesce(argument.port_name.value, "grafana") + "@Running@true"
       action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
     }
 
     // set the namespace label

--- a/modules/ui/grafana/metrics.alloy
+++ b/modules/ui/grafana/metrics.alloy
@@ -37,8 +37,8 @@ declare "kubernetes" {
 
     selectors {
       role = "pod"
-      field = join(coalesce(argument.field_selectors.value, []), ",")
-      label = join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=grafana"]), ",")
+      field = string.join(coalesce(argument.field_selectors.value, []), ",")
+      label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=grafana"]), ",")
     }
 
     namespaces {
@@ -153,7 +153,7 @@ declare "local" {
   discovery.relabel "local" {
     targets = [
       {
-        "__address__" = "localhost" + format("%s", coalesce(argument.port.value, "3000")),
+        "__address__" = "localhost" + string.format("%s", coalesce(argument.port.value, "3000")),
         "source" = "local",
       },
     ]

--- a/modules/utils/logs/log-levels.alloy
+++ b/modules/utils/logs/log-levels.alloy
@@ -17,9 +17,9 @@ declare "default_level" {
     forward_to = argument.forward_to.value
 
     /*******************************************************************************
-    *                         Log-Level Parsing
+    *                       Set baseline level and log_type
     ********************************************************************************/
-    // default level to unknown
+    // default level to value or default_level (default: unknown)
     stage.static_labels {
       values = {
         level = argument.default_level.value,
@@ -32,6 +32,26 @@ declare "default_level" {
         log_type = "unknown",
       }
     }
+  }
+}
+
+declare "klog_format" {
+  argument "forward_to" {
+    comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
+  }
+
+  argument "default_level" {
+    comment = "The default log level to use if one is not set (default: unknown)"
+    optional = true
+    default = "unknown"
+  }
+
+  export "receiver" {
+    value = loki.process.format_klog.receiver
+  }
+
+  loki.process "format_klog" {
+    forward_to = argument.forward_to.value
 
     // check to see if the log line matches the klog format (https://github.com/kubernetes/klog)
     stage.match {
@@ -85,6 +105,26 @@ declare "default_level" {
         }
       }
     }
+  }
+}
+
+declare "zerolog_format" {
+  argument "forward_to" {
+    comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
+  }
+
+  argument "default_level" {
+    comment = "The default log level to use if one is not set (default: unknown)"
+    optional = true
+    default = "unknown"
+  }
+
+  export "receiver" {
+    value = loki.process.format_zerolog.receiver
+  }
+
+  loki.process "format_zerolog" {
+    forward_to = argument.forward_to.value
 
     // check to see if the log line matches the zerolog format
     stage.match {
@@ -111,6 +151,26 @@ declare "default_level" {
         }
       }
     }
+  }
+}
+
+declare "json_format" {
+  argument "forward_to" {
+    comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
+  }
+
+  argument "default_level" {
+    comment = "The default log level to use if one is not set (default: unknown)"
+    optional = true
+    default = "unknown"
+  }
+
+  export "receiver" {
+    value = loki.process.format_json.receiver
+  }
+
+  loki.process "format_json" {
+    forward_to = argument.forward_to.value
 
     // check to see if the log line matches the json format
     stage.match {
@@ -138,6 +198,26 @@ declare "default_level" {
         }
       }
     }
+  }
+}
+
+declare "logfmt_format" {
+  argument "forward_to" {
+    comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
+  }
+
+  argument "default_level" {
+    comment = "The default log level to use if one is not set (default: unknown)"
+    optional = true
+    default = "unknown"
+  }
+
+  export "receiver" {
+    value = loki.process.format_logfmt.receiver
+  }
+
+  loki.process "format_logfmt" {
+    forward_to = argument.forward_to.value
 
     // check to see if the log line matches the logfmt format
     stage.match {
@@ -164,6 +244,26 @@ declare "default_level" {
         }
       }
     }
+  }
+}
+
+declare "unknown_format" {
+  argument "forward_to" {
+    comment = "Must be a list(LogsReceiver) where collected logs should be forwarded to"
+  }
+
+  argument "default_level" {
+    comment = "The default log level to use if one is not set (default: unknown)"
+    optional = true
+    default = "unknown"
+  }
+
+  export "receiver" {
+    value = loki.process.format_unknown.receiver
+  }
+
+  loki.process "format_unknown" {
+    forward_to = argument.forward_to.value
 
     // if the level is still unknown, do one last attempt at detecting it based on common levels
     stage.match {

--- a/modules/utils/logs/log-levels.alloy
+++ b/modules/utils/logs/log-levels.alloy
@@ -26,7 +26,7 @@ declare "default_level" {
       }
     }
 
-    // default level to unknown
+    // default type to unknown
     stage.static_labels {
       values = {
         log_type = "unknown",
@@ -105,6 +105,59 @@ declare "default_level" {
       }
 
       // set the extracted level to be a label
+      stage.labels {
+        values = {
+          level = "",
+        }
+      }
+    }
+
+    // check to see if the log line matches the json format
+    stage.match {
+      // unescaped regex: ^\s*\{.+\}\s*$
+      selector = "{level=\"" + argument.default_level.value + "\"} |~ \"^\\\\s*\\\\{.+\\\\}\\\\s*$\""
+
+      // set the log_type
+      stage.static_labels{
+        values = {
+          log_type = "json",
+        }
+      }
+
+      // extract the level
+      stage.json {
+        expressions = {
+          level = "level || lvl || loglevel || LogLevel || log_level || logLevel || log_lvl || logLvl || levelname || levelName || LevelName",
+        }
+      }
+
+      // set the extracted level as a label
+      stage.labels {
+        values = {
+          level = "",
+        }
+      }
+    }
+
+    // check to see if the log line matches the logfmt format
+    stage.match {
+      // unescaped regex: ^(\w+=("[^"]*"|\S+))(\s+(\w+=("[^"]*"|\S+)))*\s*
+      selector = "{level=\"" + argument.default_level.value + "\"} |~ \"^(\\\\w+=(\\\"[^\\\"]*\\\"|\\\\S+))(\\\\s+(\\\\w+=(\\\"[^\\\"]*\\\"|\\\\S+)))*\\\\s*\""
+
+      // set the log_type
+      stage.static_labels{
+        values = {
+          log_type = "logfmt",
+        }
+      }
+
+      // while the level could be extracted as logfmt, this allows for multiple possible log levels formats
+      // i.e. loglevel=info, level=info, lvl=info, loglvl=info
+      stage.regex {
+        expression = "(log)?(level|lvl)=\"?(?P<level>\\S+)\"?"
+      }
+
+      // set the extracted level value as a label
       stage.labels {
         values = {
           level = "",


### PR DESCRIPTION
In `modules/kubernetes/annotations/metrics.alloy` add an attribute `job_format` which defaults to `$1/$2`. This equals `namespace/pod_controller_name`. But since its set by that attribute, it can be overridden to something different. An example is that I am setting it to `$2` so the job name doesn't have the namespace in it and matches the log job names. The default behavior is the same as before this change.