### PR TITLE
fix: target kubernetes mirror pod logs

### DIFF
--- a/modules/kubernetes/core/logs.alloy
+++ b/modules/kubernetes/core/logs.alloy
@@ -18,12 +18,14 @@ declare "from_worker" {
     // DO NOT delete this line as it is needed to tail the pod logs on the node
     rule {
       action = "replace"
-      separator = "/"
+      separator = ";"
       source_labels = [
+        "__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror",
         "__meta_kubernetes_pod_uid",
         "__meta_kubernetes_pod_container_name",
       ]
-      replacement = "/var/log/pods/*$1/*.log"
+      regex = "^(?:([a-f0-9]{32});.*|;([a-f0-9\\-]+));(.+)$"
+      replacement = "/var/log/pods/*$1$2/$3/*.log"
       target_label = "__path__"
     }
 

--- a/modules/kubernetes/core/logs.alloy
+++ b/modules/kubernetes/core/logs.alloy
@@ -24,8 +24,8 @@ declare "from_worker" {
         "__meta_kubernetes_pod_uid",
         "__meta_kubernetes_pod_container_name",
       ]
-      regex = "^(?:([a-f0-9]{32});.*|;([a-f0-9\\-]+));(.+)$"
-      replacement = "/var/log/pods/*$1$2/$3/*.log"
+      regex = "^(?:;*)?([^;]+);(?:[^;]+;)?(.+)"
+      replacement = "/var/log/pods/*$1/$2/*.log"
       target_label = "__path__"
     }
 


### PR DESCRIPTION
Kubernetes mirror pods (kube-apiserver, kube-controller-manager, kube-scheduler, kube-vip, etcd) don't use the same directory pattern for their log files. Regular kubernetes pods work with the structure `/var/log/pods/*<pod uid>/<container name>/*.log`, but mirror pods use the mirror hash in place of the pod uid. This fix should use the mirror hash if the annotation is available, otherwise it uses the pod uid.