### PR TITLE
chore: remove calls to deprecated functions

### DIFF
--- a/modules/cloud/grafana/cloud/README.md
+++ b/modules/cloud/grafana/cloud/README.md
@@ -1,10 +1,5 @@
 # Grafana Cloud Auto-Configuration Module
 
-> [!WARNING]
-> Currently, the Pyroscope functionality in this module is under the `public-preview` stability level. As such, to use this module, you will need to pass `--stability.level=public-preview` to your `alloy run` command.
->
-> See the docs for [`pyroscope.write`](https://grafana.com/docs/alloy/latest/reference/components/pyroscope.write/) and [Grafana Labs' Release Lifecycle](https://grafana.com/docs/release-life-cycle/) for more info on this.
-
 Module to interact with Grafana Cloud.
 
 ## Components

--- a/modules/cloud/grafana/cloud/module.alloy
+++ b/modules/cloud/grafana/cloud/module.alloy
@@ -20,10 +20,10 @@ declare "stack" {
   // Setup the prometheus remote write receiver
   prometheus.remote_write "default" {
     endpoint {
-      url = json_decode(remote.http.config.content)["hmInstancePromUrl"] + "/api/prom/push"
+      url = json_path(remote.http.config.content,".hmInstancePromUrl")[0] + "/api/prom/push"
 
       basic_auth {
-        username = json_decode(remote.http.config.content)["hmInstancePromId"]
+        username = json_path(remote.http.config.content, ".hmInstancePromId")[0]
         password = argument.token.value
       }
     }
@@ -32,10 +32,10 @@ declare "stack" {
   // Setup the loki write receiver
   loki.write "default" {
     endpoint {
-      url = json_decode(remote.http.config.content)["hlInstanceUrl"] + "/loki/api/v1/push"
+      url = json_path(remote.http.config.content, ".hlInstanceUrl")[0] + "/loki/api/v1/push"
 
       basic_auth {
-        username = json_decode(remote.http.config.content)["hlInstanceId"]
+        username = json_path(remote.http.config.content, ".hlInstanceId")[0]
         password = argument.token.value
       }
     }
@@ -43,13 +43,13 @@ declare "stack" {
 
   // Setup the traces receiver
   otelcol.auth.basic "default" {
-    username = json_decode(remote.http.config.content)["htInstanceId"]
+    username = json_path(remote.http.config.content, ".htInstanceId")[0]
     password = argument.token.value
   }
 
   otelcol.exporter.otlp "default" {
     client {
-      endpoint = json_decode(remote.http.config.content)["htInstanceUrl"] + ":443"
+      endpoint = json_path(remote.http.config.content, ".htInstanceUrl")[0] + ":443"
       auth     = otelcol.auth.basic.default.handler
     }
   }
@@ -57,10 +57,10 @@ declare "stack" {
   // Setup the pyroscope write receiver
   pyroscope.write "default" {
     endpoint {
-      url = json_decode(remote.http.config.content)["hpInstanceUrl"]
+      url = json_path(remote.http.config.content, ".hpInstanceUrl")[0]
 
       basic_auth {
-        username = json_decode(remote.http.config.content)["hpInstanceId"]
+        username = json_path(remote.http.config.content,".hpInstanceId")[0]
         password = argument.token.value
       }
     }
@@ -81,6 +81,6 @@ declare "stack" {
     value = pyroscope.write.default.receiver
   }
   export "info" {
-    value = json_decode(remote.http.config.content)
+    value = json_path(remote.http.config.content, "$")[0]
   }
 }


### PR DESCRIPTION
Updates the Grafana Cloud module from `json_decode` to `json_path` and removes the warning about stability levels as the profiling output is GA now.