### PR TITLE
Fix kubernetes job and workload labeling

### DIFF
--- a/modules/kubernetes/annotations/logs/logs.alloy
+++ b/modules/kubernetes/annotations/logs/logs.alloy
@@ -132,10 +132,10 @@ declare "pods" {
       separator = "/"
       target_label  = "workload"
     }
-    // remove the hash from the ReplicaSet
+    // remove the hash from the ReplicaSet or Job
     rule {
       source_labels = ["workload"]
-      regex = "(ReplicaSet/.+)-.+"
+      regex = "(ReplicaSet|Job/.+)-.+"
       target_label  = "workload"
     }
 

--- a/modules/kubernetes/annotations/metrics.alloy
+++ b/modules/kubernetes/annotations/metrics.alloy
@@ -402,7 +402,7 @@ declare "kubernetes" {
     rule {
       action = "replace"
       source_labels = [
-        "__meta_kubernetes_pod_controller_type",
+        "__meta_kubernetes_pod_controller_kind",
         "__meta_kubernetes_namespace",
         "__meta_kubernetes_pod_controller_name",
       ]

--- a/modules/kubernetes/annotations/metrics.alloy
+++ b/modules/kubernetes/annotations/metrics.alloy
@@ -398,7 +398,7 @@ declare "kubernetes" {
       target_label = "job"
     }
 
-    // if the controller is a ReplicaSet, drop the hash from the end of the ReplicaSet
+    // if the controller is a ReplicaSet or Job, drop the hash from the end
     rule {
       action = "replace"
       source_labels = [
@@ -407,7 +407,7 @@ declare "kubernetes" {
         "__meta_kubernetes_pod_controller_name",
       ]
       separator = ";"
-      regex = "^(?:ReplicaSet);([^;]+);([^;]+)-.+$"
+      regex = "^(?:ReplicaSet|Job);([^;]+);([^;]+)-.+$"
       replacement = "$1/$2"
       target_label = "job"
     }
@@ -474,10 +474,10 @@ declare "kubernetes" {
       replacement = "$1/$2"
       target_label  = "workload"
     }
-    // remove the hash from the ReplicaSet
+    // remove the hash from the ReplicaSet or Job
     rule {
       source_labels = ["workload"]
-      regex = "(ReplicaSet/.+)-.+"
+      regex = "(ReplicaSet|Job/.+)-.+"
       target_label  = "workload"
     }
 


### PR DESCRIPTION
Hi, this is my first contribution to Grafana, let me know if there's anything else this needs thanks!

This PR has two commits:

## fix kube label used for metrics job label

there's one spot in code using `__meta_kubernetes_pod_controller_type` but everywhere else this is `controller_kind`

[prometheus docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/) and [alloy docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.kubernetes/) both say `controller_kind` is the correct label and there is no `controller_type`

I checked, and unfortunately looks like chatgpt and google gemini are both saying controller_type is a real value when it's not

## update regex used for workload and job labels

there's 4 labels to consider here: `workload` and `job` in metrics, and `workload` and `job` in logs

`workload` and `job` share the same processing step, and in the log pipeline it directly copies the workload value to the job label making them identical

the input to the regex is the `controller_kind` label. before it was only running on `ReplicaSet` but at minimum it needs to be `ReplicaSet|Job` 

**To Note:** there are 18 other instances of `regex = "(ReplicaSet/.+)-.+"` across the named modules. I've only updated the regex in the generic kubernetes log and metric scrape jobs. I wanted to ask if you think we should just update this regex everywhere in this or another PR, or if the maintainers of database/networking/etc know it only ever runs ReplicaSets and doesn't need a Job check

----

the reason these two commits are paired together is because the metrics `job` label, by using a nonexistent name `controller_kind`, never ran the regex and ended up with the correct value in the job label from an earlier step.

current state on main: 1/4 labels works by accident
commit 1: corrects label, breaking the end result
commit 2: fixes 4/4 labels