### PR TITLE
Fix regex for normalizing info log levels

### DIFF
--- a/modules/utils/logs/log-levels.alloy
+++ b/modules/utils/logs/log-levels.alloy
@@ -169,7 +169,7 @@ declare "normalize_level" {
     // normalize info level handles INF, INFO, INFORMATION, or INFORMATIONAL
     stage.replace {
       source = "level"
-      expression = "(?i)(info?(mation(al)?)?)"
+      expression = "(?i)(info?(rmation(al)?)?)"
       replace = "info"
     }
 


### PR DESCRIPTION
Hello, thanks for the useful modules.

Original regex for `info` level normalization dropped an `r`

`expression = "(?i)(info?(mation(al)?)?)"` -> `expression = "(?i)(info?(rmation(al)?)?)"`